### PR TITLE
Update Map.vue

### DIFF
--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -24,7 +24,7 @@
             ></l-tile-layer>
             <l-tile-layer
                 v-else
-                url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
             ></l-tile-layer>
 
             <LControlLayers />


### PR DESCRIPTION
`{s}.` is no longer recommended now that we support HTTP/2 + HTTP/3.